### PR TITLE
Update control node 16 and update core

### DIFF
--- a/control/action.yml
+++ b/control/action.yml
@@ -6,6 +6,6 @@ outputs:
     description: |
       Actions that have been triggered
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   

--- a/control/package.json
+++ b/control/package.json
@@ -11,7 +11,6 @@
     "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^4.0.0",
-        "@types/node": "^18.16.3",
         "markdown-tree-parser": "^0.12.4",
         "moment": "^2.27.0"
     },

--- a/control/package.json
+++ b/control/package.json
@@ -9,8 +9,9 @@
         "test": "ts-node src/index.ts"
     },
     "dependencies": {
-        "@actions/core": "^1.2.4",
+        "@actions/core": "^1.10.0",
         "@actions/github": "^4.0.0",
+        "@types/node": "^18.16.3",
         "markdown-tree-parser": "^0.12.4",
         "moment": "^2.27.0"
     },


### PR DESCRIPTION
According to this: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows 

we just need to update core package. we also needed to move to node16

@wg could you ake a look, for some reason you dont come up in the Reviewers list